### PR TITLE
Add “representor-device” field to device-info map for PCI and VDPA devs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -106,6 +106,11 @@ This <ins>optional</ins> key’s value (type string) shall contain the PCI addre
 of the associated physical interface (in standard BDF format “dddd:BB:DD.f”) if
 available and applicable.
 
+#### 3.1.3.5 “representor-device”
+
+This <ins>optional</ins> key’s value (type string) shall contain the name
+of the representor device for PCI VF (e.g. "eth3") if available and applicable.
+
 ### 3.1.4 “vdpa”
 
 This <ins>optional</ins> (<ins>required</ins> if “type” is set to “vdpa”) key’s
@@ -142,6 +147,11 @@ a PCI device (VF or PF).
 This <ins>optional</ins> key’s value (type string) shall contain the PCI address
 of the associated physical interface (in standard BDF format “dddd:BB:DD.f”) if
 available and applicable.
+
+#### 3.1.4.6 “representor-device”
+
+This <ins>optional</ins> key’s value (type string) shall contain the name
+of the representor device for PCI VF (e.g. "eth3") if available and applicable.
 
 ### 3.1.5 “vhost-user”
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,7 +3,7 @@ Device Information Specification
 
 ***Network Plumbing Working Group***
 
-**Version 0.1.0**
+**Version 1.1.0**
 
 This document describes the de-facto standard for sharing device information
 between Device Plugins, NPWG Implementations and CNI plugins in Kubernetes.
@@ -290,7 +290,7 @@ Plugin Device Information File.
 ```
 {
     "type": "pci",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "pci": {
         "pci-address": "0000:01:02.2",
         “pf-pci-address”: "0000:01:02.0"
@@ -301,7 +301,7 @@ Plugin Device Information File.
 ```
 {
     "type": "vdpa",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "vdpa": {
         “parent-device”: “vdpa3”,
         "driver": "vhost",
@@ -313,7 +313,7 @@ Plugin Device Information File.
 ```
 {
     "type": "vhost-user",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "vhost-user": {
         "mode": "server",
         "path": "/var/run/vhost.sock"
@@ -395,7 +395,7 @@ metadata:
           <b>"device-info": 
              {
                "type": "pci",
-               "version": "1.0.0",
+               "version": "1.1.0",
                "pci":
                  { 
                    "pci-address": "0000:18:02.5"
@@ -409,7 +409,7 @@ metadata:
           <b>"device-info":
               {
                 "type": "pci",
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "pci":
                   { 
                     "pci-address": "0000:18:0a.2"
@@ -425,7 +425,7 @@ metadata:
           <b>"device-info":
               {
                 "type": "vhost-user",
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "vhost-user":
                   { 
                     "mode": "client",
@@ -440,7 +440,7 @@ metadata:
           <b>"device-info":
               {
                 "type": "vdpa”,
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "vdpa":
                   { 
                     "parent-device": "vdpa2",


### PR DESCRIPTION
We are interested to add new field for PCI devices - “representor-device”. 
This optional field should contain name of the representor device for PCI VF.

The main use-case for now is to report `representor-device` field from [accelerated-brdige-cni](https://github.com/k8snetworkplumbingwg/accelerated-bridge-cni/pull/53) and reflect this info in `k8s.v1.cni.cncf.io/network-status` annotation.

To achieve this `PciDevice` struct in [network-attachment-definition-client](https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/blob/6ace5615d26a4d00d0a24bbbfa5d5f400ce7593e/pkg/apis/k8s.cni.cncf.io/v1/types.go#L60) require update and `network-attachment-definition-client` dependency should be updated in Multus


