### PR TITLE
Update section 5.1.2 of the spec - explicit mention that CNI Plugin can update CNIDeviceInfoFile

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -337,8 +337,8 @@ Definition, the CNI plugin should receive the value of the CNI Plugin Device
 Information File as part of the RuntimeConfig section of the CNI Args.
 
 If a file exists in the CNI Plugin Device Information File path, the CNI Plugin
-can read the Device Information file it contains (that has the same content as
-the associated Device Plugin Device Information File).
+can read (the file has the same content as the associated Device Plugin Device Information File) 
+and if required update the Device Information it contains.
 
 If a file does not exist in the CNI Plugin Device Information File path, the CNI
 Plugin can write json-encoded device information to it following the Device


### PR DESCRIPTION
Add explicit mention that CNI Plugin can also update content of the file in CNIDeviceInfoFile path.

The current spec version defines that CNI Plugin can read and write DeviceInfoFile, but update operation is not defined explicitly.
Add mention of update operation explicitly for clarity.